### PR TITLE
Enhancement/optimize-blog-import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,4 @@ gem 'memory_profiler'
 
 # For call-stack profiling flamegraphs
 gem 'stackprof'
+gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (7.0.8)
       activemodel (= 7.0.8)
       activesupport (= 7.0.8)
+    activerecord-import (2.1.0)
+      activerecord (>= 4.2)
     activestorage (7.0.8)
       actionpack (= 7.0.8)
       activejob (= 7.0.8)
@@ -245,6 +247,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   bootsnap
   capybara
   cssbundling-rails

--- a/app/jobs/import_blogs_job.rb
+++ b/app/jobs/import_blogs_job.rb
@@ -1,0 +1,70 @@
+# app/jobs/import_blogs_job.rb
+
+require 'csv'
+
+class ImportBlogsJob < ApplicationJob
+  queue_as :default
+
+  def perform(csv_file, user_id)
+    # Set the user based on the provided user_id (no checks (for now) as it came from current_user)
+    user = User.find(user_id)
+
+    # This array will keep failed rows and their errors logs to be displayed at the end (after import)
+    failed_rows = []
+
+    # Read and import the CSV file in chunks of 1000 rows (GPT says foreach is faster than parse)
+    CSV.foreach(csv_file, headers: true).each_slice(1000) do |rows|
+      # Convert each row to a hash readying it for validation and import
+      blog_attrs = rows.map(&:to_h)
+
+      # Create the blog objects in memory with the user association and the attributes
+      blogs = blog_attrs.map { |attrs| user.blogs.new(attrs) }
+
+      # Validate and import the blogs in a block
+      begin
+        # This will validate and import the records in a single SQL query
+        # The `on_duplicate_key_ignore` option will skip any duplicates
+        # The invalide records will be silently skipped. Using result to capture `failed_instances`
+        result = Blog.import blogs, validate: true, on_duplicate_key_ignore: true
+
+        # If any records failed to import, we log them here
+        # The way we are currently doing it is that we simply take the instance (not CSV format)
+        # this can be improved by adding the row data to the instance but will slow down the import
+        result.failed_instances.each do |failed_blog|
+          failed_rows << {
+            blog: failed_blog,
+            errors: failed_blog.errors.full_messages
+          }
+        end
+
+      # This is for unexpected failures (outside of validations)
+      rescue => e
+        blog_attrs.each do |row|
+          failed_rows << { row_data: row, errors: [e.message] }
+        end
+      end
+    end
+
+    # After the import of complete CSV, we turn towards error reporting
+    log_failures(failed_rows)
+    # We can also send a notification to the user about the import status
+    # UserMailer.import_status(user, failed_rows).deliver_now or something on those lines
+    # We can also remove the temporary file at this stage
+  end
+
+  private
+
+  def log_failures(failed_rows)
+    return if failed_rows.empty?
+
+    Rails.logger.info "Blog Import: #{failed_rows.size} records failed"
+
+    # This will display the errors for each failed row and the row data for reference
+    # One further improvement can be to delegate this to another job which retries
+    # for a set number of times but I think it is redundant because validation failure is not accidental
+    # The user should fix and upload the CSV again - optimal
+    failed_rows.each_with_index do |fail, index|
+      Rails.logger.info "##{index + 1} — Errors: #{fail[:errors].join(', ')} | Data: #{fail[:row_data]}"
+    end
+  end
+end

--- a/app/jobs/import_blogs_job.rb
+++ b/app/jobs/import_blogs_job.rb
@@ -12,7 +12,9 @@ class ImportBlogsJob < ApplicationJob
     # This array will keep failed rows and their errors logs to be displayed at the end (after import)
     failed_rows = []
 
-    # Read and import the CSV file in chunks of 1000 rows (GPT says foreach is faster than parse)
+    # Read and import the CSV file in chunks of 1000 rows (GPT says foreach is faster than parse although
+    # a stackoverflow post benchmarking both says that their is negligible difference - our use case
+    # is row-by-row so I preferred foreach as it goes row by row)
     CSV.foreach(csv_file, headers: true).each_slice(1000) do |rows|
       # Convert each row to a hash readying it for validation and import
       blog_attrs = rows.map(&:to_h)

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,4 +1,11 @@
 class Blog < ApplicationRecord
   belongs_to :user
   has_many :api_responses
+
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :author, presence: true
+  # We can add more validations (like a min limit for length etc. if needed - these are basic) e.g.
+  # validates :title, length: { minimum: 5 }
+  # validates :body, length: { minimum: 10 }
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -4,7 +4,6 @@ class Blog < ApplicationRecord
 
   validates :title, presence: true
   validates :body, presence: true
-  validates :author, presence: true
   # We can add more validations (like a min limit for length etc. if needed - these are basic) e.g.
   # validates :title, length: { minimum: 5 }
   # validates :body, length: { minimum: 10 }

--- a/test/jobs/blog_import_job_test.rb
+++ b/test/jobs/blog_import_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BlogImportJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
In this PR, following things have been done, commit by commit (one extra commit to remove a faulty validation):
- Added activerecord-import gem for bulk imports (bulk imports form a single SQL query for a chunk of records, 1000 in our case, which makes it performant - we can run our validations in it too - big win)
- Added validations for blog attributes - to mimic real scenario although much better validations can be added in IRL
- Replaced old import action in blogs_controller with code delegating to import_blogs_job and added private function to save file temporarily for the course of the job as the temporary files are lost when the request completes while job goes on.
- Added import_blogs_job that takes a CSV file and user_id and converts valid data into blogs chunk-by-chunk while logging full error messages for failed rows. The current failure is based on basic validations but we can make them more sophisticated to handle all at model level. If we want to handle some validations at DB level, it will complicate things but can be done. Rails is generally supposed to be rapid though ;)

Comments in the files are also somewhat detailed, trying to explain my thought process. Generally, there shouldn't be that detailed comments taking over the code in my humble opinion. The code was tested with a CSV containing a few thousand rows. It is expected that the user will enter data properly. That side of error-handling not done as of yet.