### PR TITLE
Enhancement/improve-memory-leak-job

### DIFF
--- a/app/jobs/memory_leak_job.rb
+++ b/app/jobs/memory_leak_job.rb
@@ -8,7 +8,7 @@ class MemoryLeakJob < ApplicationJob
   # The concurrent jobs will be independent of each other and will not share memory.
   def perform
     Blog.find_in_batches(batch_size: 1000) do |batch|
-      BlogBatchJob.perform_later(batch.map(&:id))
+      ProcessBlogBatchJob.perform_later(batch.map(&:id))
     end
   end
 end

--- a/app/jobs/memory_leak_job.rb
+++ b/app/jobs/memory_leak_job.rb
@@ -1,47 +1,14 @@
 class MemoryLeakJob < ApplicationJob
   queue_as :default
 
-  # The purpose of this job to take each blog record and send it to an api and save that api response. 
-
+  # The purpose of this job now is to take blog records in batches,
+  # delegate the batches to another job which hits the API and saves API responses.
+  # This will help in reducing memory usage and avoid loading all records at once.
+  # The batch size is set to 1000 (arvitrarily), but can be adjusted based on the system's memory capacity.
+  # The concurrent jobs will be independent of each other and will not share memory.
   def perform
-    blogs = Blog.all
-    
-    blogs.each do |blog|
-      validate_and_process(blog)
+    Blog.find_in_batches(batch_size: 1000) do |batch|
+      BlogBatchJob.perform_later(batch.map(&:id))
     end
-  end
-
-  private
-
-  def validate_and_process(blog)
-    # Perform some validations
-    if blog_valid?(blog)
-      # Make an API request
-      blog_to_api(blog)
-    else
-      Rails.logger.info "Invalid blog: #{blog.id}"
-    end
-
-    # Memory leak: storing blog in an array, which grows indefinitely
-    @processed_blogs ||= []
-    @processed_blogs << blog
-
-    # This prevents the blog object from being garbage collected
-  end
-
-  def blog_valid?(blog)
-    blog.title.present? && blog.body.present?
-  end
-
-  def blog_to_api(blog)
-    # Mock API call - can be replaced with real HTTP call
-    sleep(0.1) # Simulate some network latency
-    temp_id = 'blog-id'
-    # Save API Response
-    api_response_id = temp_id.gsub("id","#{SecureRandom.hex}-#{blog.id}")
-    blog.api_responses.create!(
-      api_response_id: api_response_id, 
-      api_status: ApiResponse.api_statuses.keys.sample
-    )
   end
 end

--- a/app/jobs/process_blog_batch_job.rb
+++ b/app/jobs/process_blog_batch_job.rb
@@ -4,17 +4,21 @@ class ProcessBlogBatchJob < ApplicationJob
 
   def perform(blog_ids)
     Blog.where(id: blog_ids).find_each do |blog|
+      # Perform validations as needed (is_valid? can be utilized if only model validations needed)
       next unless blog_valid?(blog)
+      # Make an API request and save the response in DB
       blog_to_api(blog)
     end
   end
 
   private
 
+  # Basic validation (copied as it was) but can be extended to include more complex checks
   def blog_valid?(blog)
     blog.title.present? && blog.body.present?
   end
 
+  # Copied from original job and slightly enhanced
   def blog_to_api(blog)
     # Mock API call - can be replaced with real HTTP call
     sleep(0.1) # Simulate some network latency

--- a/app/jobs/process_blog_batch_job.rb
+++ b/app/jobs/process_blog_batch_job.rb
@@ -1,0 +1,27 @@
+# app/jobs/process_blog_batch_job.rb
+class ProcessBlogBatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(blog_ids)
+    Blog.where(id: blog_ids).find_each do |blog|
+      next unless blog_valid?(blog)
+      blog_to_api(blog)
+    end
+  end
+
+  private
+
+  def blog_valid?(blog)
+    blog.title.present? && blog.body.present?
+  end
+
+  def blog_to_api(blog)
+    # Mock API call - can be replaced with real HTTP call
+    sleep(0.1) # Simulate some network latency
+    api_response_id = "blog-#{SecureRandom.hex}-#{blog.id}"
+    blog.api_responses.create!(
+      api_response_id: api_response_id,
+      api_status: ApiResponse.api_statuses.keys.sample
+    )
+  end
+end

--- a/app/jobs/process_blog_batch_job.rb
+++ b/app/jobs/process_blog_batch_job.rb
@@ -8,6 +8,8 @@ class ProcessBlogBatchJob < ApplicationJob
       next unless blog_valid?(blog)
       # Make an API request and save the response in DB
       blog_to_api(blog)
+      # The array saving the blogs and preventing GC from cleaning them up was serving no purpose
+      # Hence, simply removed it. If there would be a use case for it, we could consider :)
     end
   end
 

--- a/test/jobs/process_blog_batch_job_test.rb
+++ b/test/jobs/process_blog_batch_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProcessBlogBatchJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The main goal of the memory_leak job appeared to be that all blogs need to be validated and valid records are supposed to be sent to an API (faked here) and then the responses are to be saved on database.
Upon examining closely, I came up with following deductions:
- First and foremost, the processed_blogs array is unused and it is serving the purpose of hindering the garbage collector only (a classic case of memory leak as described by ChatGPT). Hence, removed simply.
- Secondly, `Blog.all` is a blind throw and in case of large database, it is going to load all in memory at once which is silly to say the least and may flood the system memory resulting in crashes at worst. The simple solution is to break this task in to chunks and delegate into threads to relieve the memory usage.
- What better than creating a separate job which takes any number of blog ids and then 'processes' them and that job is called by our main job which sends chunks of ids to the new job. The old method was to handle all jobs at once, and we have 2 options now: handle every single blog separately in the new job or break into manageable chunks. Single blog processing has one advantage that we can handle its logs well but current use case does not require that and we can go for decent-sized chunks (I went for 1000 but we can set it based on our hardware, db and use cases).
- The main job is passing only ids to the new job which conserves memory and it is efficient despite querying again because the querying is being done in batches.

Major commits:
- Added process_blog_batch_job leveraging the code from the memory_leak_job for processing blogs in chunks
- Removed extra code from memory_leak_job and added just enough for the delegation to the jobs in batches

This job can be improved further but the use case needs to be refined further for such improvements. One of the improvements can be to enhance validatons, the other being improved error handling in case of failures, for now.